### PR TITLE
plugins/check_conntrack: ignore connections marked as 'UNREPLIED' bec…

### DIFF
--- a/plugins/check_conntrack
+++ b/plugins/check_conntrack
@@ -115,7 +115,7 @@ done
 
 # Get conntrack count
 [ -r "/proc/sys/net/netfilter/nf_conntrack_count" ] || p_unknown "Unable to read the conntrack count"
-CONNTRACK_COUNT="$(cat /proc/sys/net/netfilter/nf_conntrack_count)"
+CONNTRACK_COUNT="$(conntrack -L 2>/dev/null | grep -vFc UNREPLIED)"
 [ -z "$CONNTRACK_COUNT" ] && p_unknown "Unable to read the conntrack count"
 
 # Get conntrack max


### PR DESCRIPTION
…ause they can be reused at any time by new connection. More information at http://blackbird.si/ip_conntrack-table-full-dropping-packet-conclusions-about-connection-tracking/ Closes #6